### PR TITLE
point the module to the proper directory

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -63,7 +63,7 @@
 		}
 	],
 	"system": ["dnd5e", "sw5e"],
-	"scripts": ["module/lib/jquery.sumoselect.min.js"],
+	"scripts": ["scripts/lib/jquery.sumoselect.min.js"],
 	"esmodules": ["main.js"],
 	"styles": ["styles/inventory-plus.css", "styles/sumoselect.css"],
 	"packs": [],


### PR DESCRIPTION
As-is, the module won't install. It's looking for a "module" directory inside the folder when it should be looking for "scripts"